### PR TITLE
Implement github action workflow for CD to cloudfront

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+# This workflow will checkout the contents of the `master` branch of this repo, remove all files in the current S3 bucket, and push the contents
+# to the bucket. Once the contents of the S3 bucket has been updated, a call will be made to invalidate the cache in the CloudFront distribution.
+# The CloudFront distribution is configured to pull the contents from the S3 bucket once an `invalidation` request is sent.
+
+name: Deploy to CloudFront
+
+on: # run this workflow when a push has been made to `master` branch
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1 # checks out the code in the repository
+    - name: Setup Python
+      uses: actions/setup-python@v1 # sets up python in our environment
+      with:
+        python-version: '3.x' # install python version 3.x, default architecture is x64
+    - name: Install AWS CLI
+      run: pip3 install awscli --upgrade --user # install the cli with upgrade to any requirements and into the subdir of the user
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1 # use the official GitHub Action from AWS to setup credentials
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+        mask-aws-account-id: true
+    - name: Push Contents to S3 # push the current working directory to the S3 bucket
+      run: aws s3 sync . s3://${{ secrets.S3_BUCKET_NAME }} --exclude ".git/" --delete # have bucket have the same content in the repo & exlclude the git dir.
+    - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
+      run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,6 @@ jobs:
         aws-region: ${{ secrets.AWS_REGION }}
         mask-aws-account-id: true
     - name: Push Contents to S3 # push the current working directory to the S3 bucket
-      run: aws s3 sync . s3://${{ secrets.S3_BUCKET_NAME }} --exclude ".git/" --delete # have bucket have the same content in the repo & exlclude the git dir.
+      run: aws s3 sync . s3://${{ secrets.S3_BUCKET_NAME }} --exclude ".git/*" --exclude ".github/*" --delete # have the bucket have the same content in the repo & exclude the git related directories.
     - name: Invalidate CloudFront Cache # Invalidate the CloudFront Distribution Cache to get contents from the S3 bucket
       run: aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
### What does this PR do?

This pull request sets up a GitHub Action workflow that is responsible for updating the contents of an S3 bucket that has been configured to be used with CloudFront for static site hosting.

### Any additional info?

The access token, secret token, bucket name, region, and distribution id are stored in GitHub secrets for this repository. The tokens are from a user that is restricted to only do select actions to the specific S3 bucket and to the specific CloudFront distribution.

We should be aware that once this is merged, we should see if any issues arise as we can't test the workflow until the configuration is in the `master` branch.

### How can the changes be tested?

The changes in this PR can be tested by running the following commands on your local machine with aws cli properly configured and with the correct access permissions.

1.) `aws s3 sync . s3://<bucket_name> --exclude ".git/*" --exclude ".github/*" --delete`
2.) `aws cloudfront create-invalidation --distribution-id <distribution_id> --paths "/*"`

I have ran the commands and verified in the AWS Console that the correlating S3 bucket and CloudFront distribution are updating properly.

### Issue this PR is related to?

This pull request is related to issue #2 